### PR TITLE
Add integration skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/integrations/
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+.PHONY: package packages clean run-registry
+
+INTEGRATION_PKG:=agent\
+		collector
+
+package: int_pkg=agent
+package:
+	cd package/$(int_pkg) && \
+	elastic-package check
+	
+
+packages:
+	$(foreach int_pkg,$(INTEGRATION_PKG), \
+		($(MAKE) package int_pkg=$(int_pkg) ) || exit ; \
+	)
+clean:
+	$(foreach int_pkg,$(INTEGRATION_PKG), \
+		rm -rf build/integrations/profiler_$(int_pkg) \
+	)
+
+run-registry: build-packages
+	docker-compose pull
+	docker-compose up
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+# This should start the environment with the latest snapshots.
+
+version: "3.8"
+services:
+  package-registry:
+    # to use the latest package-registry alone you can use: docker.elastic.co/package-registry/package-registry:master
+    image: docker.elastic.co/package-registry/distribution:production
+    volumes:
+      - ./package-registry.config.yml:/package-registry/config.yml
+      - ./build/integrations/:/packages/profiler-package
+    ports:
+      - "127.0.0.1:8080:8080"

--- a/package-registry.config.yml
+++ b/package-registry.config.yml
@@ -1,0 +1,6 @@
+package_paths:
+  - /packages/production
+  - /packages/staging
+  - /packages/snapshot
+  - /packages/profiler-package
+dev_mode: true

--- a/package/agent/changelog.yml
+++ b/package/agent/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.0.1"
+  changes:
+    - description: Initial draft of the package
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/0 # FIXME Replace with the real PR link

--- a/package/agent/docs/README.md
+++ b/package/agent/docs/README.md
@@ -1,0 +1,3 @@
+# Profiler Agent Integration
+
+The Profiler Agent Integration enables whole system profiling.

--- a/package/agent/img/profiler-logo-color-64px.svg
+++ b/package/agent/img/profiler-logo-color-64px.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="64px" height="64px" viewBox="0 0 64 64" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>profiler-logo-color-64px</title>
+</svg>

--- a/package/agent/manifest.yml
+++ b/package/agent/manifest.yml
@@ -1,0 +1,22 @@
+format_version: 1.1.0
+name: profiler_agent
+title: Profiler Agent
+description: Whole system profiling agent.
+version: 0.0.1
+categories: ["monitoring"]
+release: ga
+type: integration
+license: basic
+policy_templates:
+  - name: profiler agent
+    title: Profiler Agent Integration
+    description: Interact with profiler agent.
+    multiple: false
+conditions:
+  kibana.version: "^8.0.0"
+icons:
+  - src: "/img/profiler-logo-color-64px.svg"
+    size: "16x16"
+    type: "image/svg+xml"
+owner:
+  github: elastic/profiling

--- a/package/collector/changelog.yml
+++ b/package/collector/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.0.1"
+  changes:
+    - description: Initial draft of the package
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/0 # FIXME Replace with the real PR link

--- a/package/collector/docs/README.md
+++ b/package/collector/docs/README.md
@@ -1,0 +1,3 @@
+# Profiler Collection Integration
+
+The Profiler Collection Integration enables whole system profiling.

--- a/package/collector/img/profiler-logo-color-64px.svg
+++ b/package/collector/img/profiler-logo-color-64px.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="64px" height="64px" viewBox="0 0 64 64" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>profiler-logo-color-64px</title>
+</svg>

--- a/package/collector/manifest.yml
+++ b/package/collector/manifest.yml
@@ -1,0 +1,22 @@
+format_version: 1.1.0
+name: profiler_collector
+title: Stacktrace Collector
+description: Collects whole system stack traces.
+version: 0.0.1
+categories: ["monitoring"]
+release: ga
+type: integration
+license: basic
+policy_templates:
+  - name: profiler collector
+    title: Profiler Collector Integration
+    description: Interact with profiler collector.
+    multiple: false
+conditions:
+  kibana.version: "^8.0.0"
+icons:
+  - src: "/img/profiler-logo-color-64px.svg"
+    size: "16x16"
+    type: "image/svg+xml"
+owner:
+  github: elastic/profiling


### PR DESCRIPTION
Signed-off-by: Florian Lehner <flehner@optimyze.cloud>

This PR introduces a skeleton for HA and CA integrations based on [elastic/endpoint-package](https://github.com/elastic/endpoint-package) and [elastic/apm-server/apmpackage](https://github.com/elastic/apm-server/tree/master/apmpackage).
This is just the very first step by letting the package registry know about our agents. Elastic Agent itself still needs to learn about these new executables and how to install and run them. Finally the gRPC communication between our agents and the Elastic Agents needs to be established. 

# How to test
```
$ make packages
$ make run-registry
$ curl localhost:8080/search?package=profiler_agent
[
  {
    "name": "profiler_agent",
    "title": "Profiler Agent",
    "version": "0.0.1",
    "release": "ga",
    "description": "Whole system profiling agent.",
    "type": "integration",
    "download": "/epr/profiler_agent/profiler_agent-0.0.1.zip",
    "path": "/package/profiler_agent/0.0.1",
    "icons": [
      {
        "src": "/img/profiler-logo-color-64px.svg",
        "path": "/package/profiler_agent/0.0.1/img/profiler-logo-color-64px.svg",
        "size": "16x16",
        "type": "image/svg+xml"
      }
    ],
    "policy_templates": [
      {
        "name": "profiler agent",
        "title": "Profiler Agent Integration",
        "description": "Interact with profiler agent."
      }
    ],
    "conditions": {
      "kibana": {
        "version": "^8.0.0"
      }
    },
    "owner": {
      "github": "elastic/profiling"
    },
    "categories": [
      "monitoring"
    ]
  }
]
```