### PR TITLE
Use a variable for the distribution (default: production)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,10 @@ clean-package:
 	$(AT)cd package/$(pkg) && \
 	elastic-package clean $(VFLAG)
 
+# Variables:
+# $DISTRIBUTION
+#   snapshot: run snapshot EPR
+#   production: run production EPR (default)
 run-registry: packages
 	docker-compose pull
 	docker-compose up
-

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ go install github.com/elastic/elastic-package
 `make clean` cleans up the build artifacts.
 
 `make run-registry` builds the integration packages, pulls and runs the containerized Elastic Package Repository (EPR) together with the integration packages.
+ By default the 'production' distribution / container is selected. Use the snapshot (or any other) distribution with
+ `DISTRIBUTION=snapshot make run-registry`.
 
 ## How to test the package registry
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,11 @@
 # This should start the environment with the latest snapshots.
 
 version: "3.8"
+
 services:
   package-registry:
     # to use the latest package-registry alone you can use: docker.elastic.co/package-registry/package-registry:master
-    image: docker.elastic.co/package-registry/distribution:production
+    image: docker.elastic.co/package-registry/distribution:${DISTRIBUTION:-production}
     volumes:
       - ./package-registry.config.yml:/package-registry/config.yml
       - ./build/integrations/:/packages/profiler-package


### PR DESCRIPTION
This makes it more flexible when using the snapshot distribution (or any other) for testing locally.