### PR TITLE
Align package version with ES stack

### DIFF
--- a/package/agent/changelog.yml
+++ b/package/agent/changelog.yml
@@ -1,6 +1,6 @@
 # newer versions go on top
-- version: "0.0.1"
+- version: "2.3.1"
   changes:
     - description: Initial draft of the package
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/0 # FIXME Replace with the real PR link
+      link: https://github.com/elastic/profiler-package/pull/9

--- a/package/agent/manifest.yml
+++ b/package/agent/manifest.yml
@@ -2,7 +2,9 @@ format_version: 1.1.0
 name: profiler_agent
 title: Profiler Agent
 description: Whole system profiling agent.
-version: 0.0.1
+# For the version of this package we use the current version of
+# pf-host-agent for which this package is for.
+version: 2.4.1
 categories: ["monitoring"]
 release: ga
 type: integration
@@ -13,7 +15,7 @@ policy_templates:
     description: Interact with profiler agent.
     multiple: false
 conditions:
-  kibana.version: "^7.0.0"
+  kibana.version: "^8.5.0"
 icons:
   - src: "/img/profiler-logo-color-48px.svg"
     size: "48x46"


### PR DESCRIPTION
Signed-off-by: Florian Lehner <flehner@optimyze.cloud>

Version `0.x.z` is considered as a non-release version by the linter. Therefore `make package pkg=agent` fails currently with a recent version of `elastic-package`.

The version of the package is independent of the ES stack version and can be increased any time. 
Other integrations, that are not in `elastic/beats` are also aligning the version of the package with the version of the ES stack. E.g.:
https://github.com/elastic/endpoint-package/blob/3cfcb5c97d3585810542011775900de588b0ddaf/package/endpoint/manifest.yml#L5

Therefore, this PR follows this best practice.