### PR TITLE
Update URL to profiling docs

### DIFF
--- a/package/agent/docs/README.md
+++ b/package/agent/docs/README.md
@@ -33,4 +33,4 @@ The minimum supported versions are:
 * Ruby: >= 2.5
 * Perl: >= 5.28
 
-[Learn more](https://elastic.github.io/universal-profiling-documentation)
+[Learn more](https://www.elastic.co/guide/en/observability/current/universal-profiling.html)


### PR DESCRIPTION
This PR updates the `Learn More` URL to the newer Universal Profiling documentation.