### PR TITLE
Agent: add probabilistic profiling

### DIFF
--- a/package/agent/changelog.yml
+++ b/package/agent/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 2.5.4
+  changes:
+    - description: Add arguments for probabilistic profiling
+      type: enhancement
+      link: https://github.com/elastic/profiler-package/pull/17
 - version: 2.4.1
   changes:
     - description: Initial draft of the package

--- a/package/agent/manifest.yml
+++ b/package/agent/manifest.yml
@@ -2,12 +2,12 @@ name: profiler_agent
 title: Universal Profiling Agent
 # For the version of this package we use the current version of
 # pf-host-agent for which this package is for.
-version: 2.4.1
+version: 2.5.4
 categories: ["elastic_stack", "monitoring"]
 release: ga
 description: Fleet-wide, whole-system, continuous profiling with zero instrumentation.
 conditions:
-  kibana.version: ^8.7.0
+  kibana.version: ^8.8.0
 format_version: 1.1.0
 icons:
   - size: 48x46
@@ -44,6 +44,16 @@ policy_templates:
           - name: profiler.connect_proxy
             title: Connect proxy
             description: URL to proxy connections in the form of http[s]://<user>:<password>@<server name/ip>:<port>
+            show_user: true
+            type: text
+          - name: profiler.probabilistic_threshold
+            title: Probabilistic threshold
+            description: If set to a value between 1 and 99 will enable probabilistic profiling. Every probabilistic interval a random number between 0 and 99 is chosen. If the given probabilistic threshold is greater than this random number, the agent will collect profiles from this system for the duration of the interval.
+            show_user: true
+            type: integer
+          - name: profiler.probabilistic_interval
+            title: Probabilistic interval
+            description: Time interval for which probabilistic profiling will be enabled or disabled. (default 1m0s)
             show_user: true
             type: text
     multiple: false


### PR DESCRIPTION
We have merged Probabilistic Profiling into our agent. This PR fixes https://github.com/elastic/prodfiler/issues/3164. With this PR users can configure probabilistic profiling.