### PR TITLE
agent: add arguments to template

### DIFF
--- a/package/agent/agent/input/template.yml.hbs
+++ b/package/agent/agent/input/template.yml.hbs
@@ -1,3 +1,6 @@
 pf-host-agent:
     collector: {{profiler.collector}}
     secret_token: {{profiler.secret_token}}
+    connect_proxy: {{profiler.connect_proxy}}
+    probabilistic_threshold: {{profiler.probabilistic_threshold}}
+    probabilistic_interval: {{profiler.probabilistic_interval}}


### PR DESCRIPTION
The template builds the base for the arguments that are passed from Elastic Agent to the service. Without naming the arguments from the manifest in the template, these arguments will not passed to the service.